### PR TITLE
OSBuildConfig controller

### DIFF
--- a/controllers/osbuildconfig_controller.go
+++ b/controllers/osbuildconfig_controller.go
@@ -18,19 +18,25 @@ package controllers
 
 import (
 	"context"
-
+	"github.com/go-logr/logr"
+	osbuilderprojectflottaiov1alpha1 "github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"github.com/project-flotta/osbuild-operator/internal/repository/osbuild"
+	"github.com/project-flotta/osbuild-operator/internal/repository/osbuildconfig"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	osbuilderprojectflottaiov1alpha1 "github.com/project-flotta/osbuild-operator/api/v1alpha1"
 )
 
 // OSBuildConfigReconciler reconciles a OSBuildConfig object
 type OSBuildConfigReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme                  *runtime.Scheme
+	OSBuildConfigRepository osbuildconfig.Repository
+	OSBuildRepository       osbuild.Repository
 }
 
 //+kubebuilder:rbac:groups=osbuilder.project-flotta.io,resources=osbuildconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -47,11 +53,70 @@ type OSBuildConfigReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *OSBuildConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling", "OSBuildConfig", req)
 
-	// TODO(user): your logic here
+	osBuildConfig, err := r.OSBuildConfigRepository.Read(ctx, req.Name, req.Namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	if osBuildConfig.DeletionTimestamp != nil {
+		// The OSBuild CRs that were created by that OSBuildConfig would be deleted
+		// thanks to setting controller reference for each OSBuild CR
+		return ctrl.Result{}, nil
+	}
+
+	err = r.createNewOSBuildCR(ctx, osBuildConfig, logger)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, err
+	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *OSBuildConfigReconciler) createNewOSBuildCR(ctx context.Context, osBuildConfig *osbuilderprojectflottaiov1alpha1.OSBuildConfig, logger logr.Logger) error {
+	osBuildNewVersion := *osBuildConfig.Status.LastVersion + 1
+
+	osBuildConfigSpecDetails := osBuildConfig.Spec.Details.DeepCopy()
+	osBuild := &osbuilderprojectflottaiov1alpha1.OSBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: osBuildConfig.Name + "-" + string(rune(osBuildNewVersion)),
+		},
+		Spec: osbuilderprojectflottaiov1alpha1.OSBuildSpec{
+			Details:     *osBuildConfigSpecDetails,
+			TriggeredBy: "UpdateCR",
+		},
+	}
+
+	// Set the owner of the osBuild CR to be osBuildConfig in order to manage lifecycle of the osBuild CR.
+	// Especially in deletion of osBuildConfig CR
+	err := controllerutil.SetControllerReference(osBuildConfig, osBuild, r.Scheme)
+	if err != nil {
+		logger.Error(err, "cannot create osBuild")
+		return err
+	}
+
+	patch := client.MergeFrom(osBuildConfig.DeepCopy())
+	osBuildConfig.Status.LastVersion = &osBuildNewVersion
+	err = r.OSBuildConfigRepository.PatchStatus(ctx, osBuildConfig, &patch)
+	if err != nil {
+		logger.Error(err, "cannot update the field lastVersion of osBuildConfig")
+		return err
+	}
+
+	err = r.OSBuildRepository.Create(ctx, osBuild)
+	if err != nil {
+		logger.Error(err, "cannot create osBuild")
+		return err
+	}
+
+	logger.Info("A new OSBuild CR was created", osBuild.Name)
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/repository/osbuild/osbuild.go
+++ b/internal/repository/osbuild/osbuild.go
@@ -1,0 +1,31 @@
+package osbuild
+
+import (
+	"context"
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:generate mockgen -package=osbuild -destination=mock_osbuild.go . Repository
+type Repository interface {
+	Read(ctx context.Context, name string, namespace string) (*v1alpha1.OSBuild, error)
+	Create(ctx context.Context, osBuild *v1alpha1.OSBuild) error
+}
+
+type CRRepository struct {
+	client client.Client
+}
+
+func NewOSBuildRepository(client client.Client) *CRRepository {
+	return &CRRepository{client: client}
+}
+
+func (r *CRRepository) Read(ctx context.Context, name string, namespace string) (*v1alpha1.OSBuild, error) {
+	osBuild := v1alpha1.OSBuild{}
+	err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &osBuild)
+	return &osBuild, err
+}
+
+func (r *CRRepository) Create(ctx context.Context, osBuild *v1alpha1.OSBuild) error {
+	return r.client.Create(ctx, osBuild)
+}

--- a/internal/repository/osbuildconfig/osbuildconfig.go
+++ b/internal/repository/osbuildconfig/osbuildconfig.go
@@ -1,0 +1,31 @@
+package osbuildconfig
+
+import (
+	"context"
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:generate mockgen -package=osbuildconfig -destination=mock_osbuildconfig.go . Repository
+type Repository interface {
+	Read(ctx context.Context, name string, namespace string) (*v1alpha1.OSBuildConfig, error)
+	PatchStatus(ctx context.Context, osbuildConfig *v1alpha1.OSBuildConfig, patch *client.Patch) error
+}
+
+type CRRepository struct {
+	client client.Client
+}
+
+func NewOSBuildConfigRepository(client client.Client) *CRRepository {
+	return &CRRepository{client: client}
+}
+
+func (r *CRRepository) Read(ctx context.Context, name string, namespace string) (*v1alpha1.OSBuildConfig, error) {
+	osBuildConfig := v1alpha1.OSBuildConfig{}
+	err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &osBuildConfig)
+	return &osBuildConfig, err
+}
+
+func (r *CRRepository) PatchStatus(ctx context.Context, osbuildConfig *v1alpha1.OSBuildConfig, patch *client.Patch) error {
+	return r.client.Status().Patch(ctx, osbuildConfig, *patch)
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"github.com/project-flotta/osbuild-operator/internal/repository/osbuild"
+	"github.com/project-flotta/osbuild-operator/internal/repository/osbuildconfig"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -84,9 +86,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	OSBuildConfigRepository := osbuildconfig.NewOSBuildConfigRepository(mgr.GetClient())
+	OSBuildRepository := osbuild.NewOSBuildRepository(mgr.GetClient())
+
 	if err = (&controllers.OSBuildConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		OSBuildConfigRepository: OSBuildConfigRepository,
+		OSBuildRepository:       OSBuildRepository,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OSBuildConfig")
 		os.Exit(1)


### PR DESCRIPTION
After creating a new OSBuildConfig CR or updating an existing CR (by the user) a new OSBuild CR should be created.
The OSBuildConfig controller is triggering a new OSBuild CR per update or creation of OSBuildConfig CR

Signed-off-by: Danielle Barda [dbarda@redhat.com](mailto:dbarda@redhat.com)