### PR TITLE
Index OSBuildConfig by OSBuildConfigTemplate

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1,0 +1,27 @@
+package indexer
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+)
+
+const (
+	// ConfigByConfigTemplate is the name of the indexer for OSBuildConfig by OSBuildConfigTemplate name
+	ConfigByConfigTemplate = "config-by-template"
+)
+
+func ConfigByTemplateIndexFunc(obj client.Object) []string {
+	config, ok := obj.(*v1alpha1.OSBuildConfig)
+	if !ok {
+		return []string{}
+	}
+	if config.Spec.Template == nil {
+		return []string{}
+	}
+	if config.Spec.Template.OSBuildConfigTemplateRef == "" {
+		return []string{}
+	}
+
+	return []string{config.Spec.Template.OSBuildConfigTemplateRef}
+}

--- a/internal/indexer/indexer_suite_test.go
+++ b/internal/indexer/indexer_suite_test.go
@@ -1,0 +1,13 @@
+package indexer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Indexers Spec")
+}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1,0 +1,63 @@
+package indexer_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"github.com/project-flotta/osbuild-operator/internal/indexer"
+)
+
+var _ = Describe("Index functions", func() {
+
+	Context("Index func of os build config", func() {
+		It("should create key", func() {
+			// given
+			templateRef := "template-ref"
+
+			config := v1alpha1.OSBuildConfig{
+				Spec: v1alpha1.OSBuildConfigSpec{
+					Template: &v1alpha1.Template{
+						OSBuildConfigTemplateRef: templateRef,
+					},
+				},
+			}
+
+			// when
+			keys := indexer.ConfigByTemplateIndexFunc(&config)
+
+			// then
+			Expect(keys).To(HaveLen(1))
+			Expect(keys).Should(ConsistOf(templateRef))
+		})
+
+		DescribeTable("should create no keys", func(template *v1alpha1.Template) {
+			// given
+			config := v1alpha1.OSBuildConfig{
+				Spec: v1alpha1.OSBuildConfigSpec{
+					Template: template,
+				},
+			}
+
+			// when
+			keys := indexer.ConfigByTemplateIndexFunc(&config)
+
+			// then
+			Expect(keys).To(BeEmpty())
+		},
+			Entry("no template", nil),
+			Entry("no template ref", &v1alpha1.Template{}))
+
+		It("should create no keys for wrong type", func() {
+			// given
+			notAConfig := v1alpha1.OSBuild{}
+
+			// when
+			keys := indexer.ConfigByTemplateIndexFunc(&notAConfig)
+
+			// then
+			Expect(keys).To(BeEmpty())
+		})
+	})
+
+})

--- a/internal/repository/osbuildconfig/mock_osbuildconfig.go
+++ b/internal/repository/osbuildconfig/mock_osbuildconfig.go
@@ -36,6 +36,21 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
+// ListByOSBuildConfigTemplate mocks base method.
+func (m *MockRepository) ListByOSBuildConfigTemplate(arg0 context.Context, arg1, arg2 string) ([]v1alpha1.OSBuildConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByOSBuildConfigTemplate", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]v1alpha1.OSBuildConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByOSBuildConfigTemplate indicates an expected call of ListByOSBuildConfigTemplate.
+func (mr *MockRepositoryMockRecorder) ListByOSBuildConfigTemplate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByOSBuildConfigTemplate", reflect.TypeOf((*MockRepository)(nil).ListByOSBuildConfigTemplate), arg0, arg1, arg2)
+}
+
 // PatchStatus mocks base method.
 func (m *MockRepository) PatchStatus(arg0 context.Context, arg1 *v1alpha1.OSBuildConfig, arg2 *client.Patch) error {
 	m.ctrl.T.Helper()

--- a/internal/repository/osbuildconfig/osbuildconfig.go
+++ b/internal/repository/osbuildconfig/osbuildconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "github.com/golang/mock/mockgen/model"
 	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"github.com/project-flotta/osbuild-operator/internal/indexer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -11,6 +12,7 @@ import (
 type Repository interface {
 	Read(ctx context.Context, name string, namespace string) (*v1alpha1.OSBuildConfig, error)
 	PatchStatus(ctx context.Context, osbuildConfig *v1alpha1.OSBuildConfig, patch *client.Patch) error
+	ListByOSBuildConfigTemplate(ctx context.Context, templateName string, namespace string) ([]v1alpha1.OSBuildConfig, error)
 }
 
 type CRRepository struct {
@@ -29,4 +31,16 @@ func (r *CRRepository) Read(ctx context.Context, name string, namespace string) 
 
 func (r *CRRepository) PatchStatus(ctx context.Context, osbuildConfig *v1alpha1.OSBuildConfig, patch *client.Patch) error {
 	return r.client.Status().Patch(ctx, osbuildConfig, *patch)
+}
+
+func (r *CRRepository) ListByOSBuildConfigTemplate(ctx context.Context, templateName string, namespace string) ([]v1alpha1.OSBuildConfig, error) {
+	configs := v1alpha1.OSBuildConfigList{}
+	err := r.client.List(ctx, &configs,
+		client.MatchingFields{indexer.ConfigByConfigTemplate: templateName},
+		client.InNamespace(namespace),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return configs.Items, nil
 }

--- a/main.go
+++ b/main.go
@@ -135,8 +135,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.OSBuildConfigTemplateReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		OSBuildConfigRepository: OSBuildConfigRepository,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OSBuildConfigTemplate")
 		os.Exit(1)


### PR DESCRIPTION
This PR adds cache index to support retrieving `OSBuildConfig` objects by the name of `OSBuildConfigTemplate` it uses.