### PR TITLE
Osbuildconfig predicate

### DIFF
--- a/controllers/osbuildconfig_controller.go
+++ b/controllers/osbuildconfig_controller.go
@@ -19,8 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	osbuilderprojectflottaiov1alpha1 "github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"github.com/project-flotta/osbuild-operator/internal/predicates"
 	"github.com/project-flotta/osbuild-operator/internal/repository/osbuild"
 	"github.com/project-flotta/osbuild-operator/internal/repository/osbuildconfig"
 )
@@ -134,7 +133,7 @@ func (r *OSBuildConfigReconciler) createNewOSBuildCR(ctx context.Context, osBuil
 func (r *OSBuildConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&osbuilderprojectflottaiov1alpha1.OSBuildConfig{}).
-		// Process only spec changes
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		// Process only spec changes or when related template versions diverge
+		WithEventFilter(predicates.OSBuildConfigChangedPredicate{}).
 		Complete(r)
 }

--- a/internal/predicates/osbuildconfig.go
+++ b/internal/predicates/osbuildconfig.go
@@ -1,0 +1,35 @@
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+)
+
+type OSBuildConfigChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (OSBuildConfigChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		return false
+	}
+	if e.ObjectNew == nil {
+		return false
+	}
+
+	newConfig, ok := e.ObjectNew.(*v1alpha1.OSBuildConfig)
+	if !ok {
+		return false
+	}
+
+	generationChanged := e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
+
+	var templateChanged bool
+	if newConfig.Status.LastTemplateResourceVersion != nil && newConfig.Status.CurrentTemplateResourceVersion != nil {
+		templateChanged = newConfig.Status.LastTemplateResourceVersion != newConfig.Status.CurrentTemplateResourceVersion
+	}
+
+	return generationChanged || templateChanged
+}

--- a/internal/predicates/osbuildconfig_test.go
+++ b/internal/predicates/osbuildconfig_test.go
@@ -1,0 +1,156 @@
+package predicates_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/project-flotta/osbuild-operator/api/v1alpha1"
+	"github.com/project-flotta/osbuild-operator/internal/predicates"
+)
+
+var (
+	version1 = "1"
+	version2 = "2"
+)
+
+var _ = Describe("OSBuildConfig reconciliation predicate", func() {
+	DescribeTable("should reconcile update", func(old, new runtimeclient.Object) {
+		// given
+		p := predicates.OSBuildConfigChangedPredicate{}
+		e := event.UpdateEvent{ObjectOld: old, ObjectNew: new}
+
+		// when
+		shouldReconcile := p.Update(e)
+
+		// then
+		Expect(shouldReconcile).To(BeTrue())
+	},
+		Entry("when generation changes",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 2},
+			},
+		),
+		Entry("when template version changed",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.OSBuildConfigStatus{
+					LastTemplateResourceVersion:    &version1,
+					CurrentTemplateResourceVersion: &version2,
+				},
+			},
+		),
+	)
+
+	DescribeTable("should not reconcile update", func(old, new runtimeclient.Object) {
+		// given
+		p := predicates.OSBuildConfigChangedPredicate{}
+		e := event.UpdateEvent{ObjectOld: old, ObjectNew: new}
+
+		// when
+		shouldReconcile := p.Update(e)
+
+		// then
+		Expect(shouldReconcile).To(BeFalse())
+	},
+		Entry("when nothing changes",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+		),
+		Entry("when last template version is missing",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.OSBuildConfigStatus{
+					CurrentTemplateResourceVersion: &version2,
+				},
+			},
+		),
+		Entry("when current template version is missing",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.OSBuildConfigStatus{
+					LastTemplateResourceVersion: &version1,
+				},
+			},
+		),
+		Entry("when old is missing",
+			nil,
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+		),
+		Entry("when new is missing",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			nil,
+		),
+		Entry("when new is not OSBuildConfig",
+			&v1alpha1.OSBuildConfig{
+				ObjectMeta: v1.ObjectMeta{Generation: 1},
+			},
+			&v1alpha1.OSBuild{},
+		),
+	)
+
+	It("should reconcile create", func() {
+		// given
+		p := predicates.OSBuildConfigChangedPredicate{}
+		e := event.CreateEvent{Object: &v1alpha1.OSBuildConfig{
+			ObjectMeta: v1.ObjectMeta{Generation: 1},
+		}}
+
+		// when
+		shouldReconcile := p.Create(e)
+
+		// then
+		Expect(shouldReconcile).To(BeTrue())
+	})
+
+	It("should reconcile delete", func() {
+		// given
+		p := predicates.OSBuildConfigChangedPredicate{}
+		e := event.DeleteEvent{Object: &v1alpha1.OSBuildConfig{
+			ObjectMeta: v1.ObjectMeta{Generation: 1},
+		}}
+
+		// when
+		shouldReconcile := p.Delete(e)
+
+		// then
+		Expect(shouldReconcile).To(BeTrue())
+	})
+
+	It("should reconcile for generic event", func() {
+		// given
+		p := predicates.OSBuildConfigChangedPredicate{}
+		e := event.GenericEvent{Object: &v1alpha1.OSBuildConfig{
+			ObjectMeta: v1.ObjectMeta{Generation: 1},
+		}}
+
+		// when
+		shouldReconcile := p.Generic(e)
+
+		// then
+		Expect(shouldReconcile).To(BeTrue())
+	})
+})

--- a/internal/predicates/predicates_suite_test.go
+++ b/internal/predicates/predicates_suite_test.go
@@ -1,0 +1,13 @@
+package predicates_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicates Suite")
+}


### PR DESCRIPTION
This PR adds custom reconciliation predicate/event filter to allow reconciliation of only `OSBuildConfig` objects for which either genreation changed (which would mean that spec changed) or `status.LastTemplateResourceVersion`!=`status.CurrentTemplateResourceVersion` (which would mean that template was updated).

Code responsible for updating above versions will be implemented in another PR.